### PR TITLE
Update the response schema and example

### DIFF
--- a/salesforce-webhook-response-sample-data.json
+++ b/salesforce-webhook-response-sample-data.json
@@ -1,54 +1,24 @@
 {
-  "pos_order_id": "142857",
-  "sf_product_type": "Open Enrollment",
+  "pos_order_id": 20,
   "sf_order_id": "a0r0P00000HX7fh",
-  "sf_payment_id": "a370P00000bcH7R",
-  "sf_contacts": [
+  "payments": [
     {
-      "status": "updated",
-      "contact_sfid": "0020P000005G47x",
-      "first_name": "Kim",
-      "last_name": "Sampler",
-      "email": "ksampler@acme.com",
-      "company": "Acme, Inc.",
-      "job_title": "Director of Training",
-      "phone": "607-255-5555",
-      "participant_in": []
+      "pos_payment_id": 9,
+      "sf_payment_id": "a370P00000bcH7R"
+    }
+  ],
+  "customer": {
+    "pos_customer_id": 3,
+    "sf_customer_contact_id": "0020P000005G47x"
+  },
+  "participants": [
+    {
+      "pos_participant_id": 17,
+      "sf_participant_contact_id": "0033J000006sj3sQAA"
     },
     {
-      "status": "updated",
-      "contact_sfid": "0250F000002Z32x",
-      "first_name": "Ralph",
-      "last_name": "Remmington",
-      "email": "rremmington@acme.com",
-      "company": "Acme, Inc.",
-      "job_title": "HR Analyst",
-      "phone": "607-255-4444",
-      "participant_in": [
-        {
-          "class_id": "a0i0P00000SgpG8",
-          "participant_id": "d102S00050GEyPL",
-          "sf_application_id": "a0r0P00000JR3pt"
-        }
-      ]
-    },
-    {
-      "status": "updated",
-      "pos_user_id": "714285",
-      "contact_sfid": "0005M000066Q96x",
-      "first_name": "Lawanda",
-      "last_name": "Jordan",
-      "email": "ljordan@acme.com",
-      "company": "Acme, Inc.",
-      "job_title": "Director of Talent Development",
-      "phone": "607-255-4321",
-      "participant_in": [
-        {
-          "class_id": "a0i0P00000SgpG8",
-          "participant_id": "0070P00350BVGKj",
-          "sf_application_id": "a0r0W00920KD7ag"
-        }
-      ]
+      "pos_participant_id": 18,
+      "sf_participant_contact_id": "0030P00002LZQ3xQAH"
     }
   ]
 }

--- a/salesforce-webhook-response-sample-data.json
+++ b/salesforce-webhook-response-sample-data.json
@@ -14,11 +14,11 @@
   "participants": [
     {
       "pos_participant_id": 17,
-      "sf_participant_contact_id": "0033J000006sj3sQAA"
+      "sf_participant_id": "a103J0000007i6OQAQ",
     },
     {
       "pos_participant_id": 18,
-      "sf_participant_contact_id": "0030P00002LZQ3xQAH"
+      "sf_participant_id": "a100P00000MAW58QAH",
     }
   ]
 }

--- a/salesforce-webhook-response-schema.json
+++ b/salesforce-webhook-response-schema.json
@@ -38,9 +38,9 @@
         "type": "object",
         "properties": {
           "pos_participant_id": { "type": "integer" },
-          "sf_participant_contact_id": { "$ref": "#/definitions/sales_force_id" }
+          "sf_participant_id": { "$ref": "#/definitions/sales_force_id" }
         },
-        "required": ["pos_participant_id", "sf_participant_contact_id"]
+        "required": ["pos_participant_id", "sf_participant_id"]
       }
     }
   },

--- a/salesforce-webhook-response-schema.json
+++ b/salesforce-webhook-response-schema.json
@@ -6,66 +6,45 @@
   "type": "object",
   "properties": {
     "pos_order_id": {
-      "type": "string",
+      "type": "integer",
       "description": "The point of sale's unique id for the order."
     },
     "sf_order_id": {
-      "type": "string",
+      "$ref": "#/definitions/sales_force_id",
       "description": "Salesforce's unique id for the order."
     },
-    "sf_payment_id": { "$ref": "#/definitions/sales_force_id" },
-    "sf_contacts": {
+    "payments": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "status": {
-            "type": "string",
-            "enum": [ "updated", "inserted" ]
-          },
-          "contact_sfid": { "$ref": "#/definitions/sales_force_id" },
-          "first_name": { "type": "string" },
-          "last_name": { "type": "string" },
-          "email": { "type": "string" },
-          "company": { "type": "string"},
-          "job_title": { "type": "string"},
-          "phone": { "type": "string" },
-          "participant_in": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "class_id": { "$ref": "#/definitions/sales_force_id" },
-                "participant_id": { "$ref": "#/definitions/sales_force_id" },
-                "sf_application_id": { "$ref": "#/definitions/sales_force_id" },
-                "sf_certificate_id": {
-                  "description": "id of certificate toward which participant wants to apply this course",
-                  "$ref": "#/definitions/sales_force_id"
-                }
-              },
-              "required": ["class_id", "participant_id", "sf_application_id"]
-            }
-          },
-          "certificate_enrollment_requests_recorded_for": {
-            "description": "Include here only certificate enrollments not already requested as part of individual class registrations",
-            "type": "array",
-            "itmes": {
-              "type": "object",
-              "properties": {
-                "sf_certificate_id": {
-                  "description": "id of certificate toward which participant wants to apply this course",
-                  "$ref": "#/definitions/sales_force_id"
-                },
-                "required": ["sf_certificate_id"]
-              }
-            }
-          }
+          "pos_payment_id": { "type": "integer" },
+          "sf_payment_id": { "$ref": "#/definitions/sales_force_id" }
         },
-        "required": ["status","contact_sfid","email"]
+        "required": ["pos_payment_id", "sf_payment_id"]
+      }
+    },
+    "customer": {
+      "type": "object",
+      "properties": {
+        "pos_customer_id": { "type": "integer" },
+        "sf_customer_contact_id": { "$ref": "#/definitions/sales_force_id" }
+      },
+      "required": ["pos_customer_id", "sf_customer_contact_id"]
+    },
+    "participants": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "pos_participant_id": { "type": "integer" },
+          "sf_participant_contact_id": { "$ref": "#/definitions/sales_force_id" }
+        },
+        "required": ["pos_participant_id", "sf_participant_contact_id"]
       }
     }
   },
-  "required": ["pos_order_id", "sf_order_id", "sf_payment_id", "sf_contacts"],
+  "required": ["pos_order_id", "sf_order_id", "payments", "customer", "participants"],
   "definitions": {
     "sales_force_id": {
       "type": "string",


### PR DESCRIPTION
- Change payments to an array with a simple sf_id to pos_id mapping.
- Add a dedicated `customer` property for the sf custom contact id to map to the pos customer id (e.g. the billing profile entity in Drupal).
- Change contacts to an array of participants with a simple salesforce contact id to pos participant id mapping.
- Remove all address, email, and phone fields from contacts. We can get them from the salesforce object if we ever need them.
- Remove the certificate-related fields since we don't yet know what to do with them and we can probably get them from an api call to salesforce.
- Change all pos ids to integers.