### PR TITLE
Simplify the incoming response schema

### DIFF
--- a/salesforce-webhook-response-sample-data.json
+++ b/salesforce-webhook-response-sample-data.json
@@ -1,26 +1,3 @@
 {
-  "pos_order_id": 20,
-  "sf_order_id": "a0r0P00000HX7fh",
-  "payments": [
-    {
-      "pos_payment_id": 9,
-      "sf_payment_id": "a370P00000bcH7R"
-    }
-  ],
-  "customer": {
-    "pos_customer_id": 3,
-    "sf_customer_contact_id": "0020P000005G47x"
-  },
-  "participants": [
-    {
-      "pos_participant_id": 17,
-      "sf_participant_contact_id": "0020P000005G47x",
-      "sf_participant_id": "a103J0000007i6OQAQ"
-    },
-    {
-      "pos_participant_id": 18,
-      "sf_participant_contact_id": "0480R000007L33n",
-      "sf_participant_id": "a100P00000MAW58QAH"
-    }
-  ]
+  "sf_order_id": "a0r0P00000HX7fh"
 }

--- a/salesforce-webhook-response-schema.json
+++ b/salesforce-webhook-response-schema.json
@@ -5,47 +5,12 @@
   "description": "Data returned by Salesforce after a successful order.",
   "type": "object",
   "properties": {
-    "pos_order_id": {
-      "type": "integer",
-      "description": "The point of sale's unique id for the order."
-    },
     "sf_order_id": {
       "$ref": "#/definitions/sales_force_id",
       "description": "Salesforce's unique id for the order."
-    },
-    "payments": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "pos_payment_id": { "type": "integer" },
-          "sf_payment_id": { "$ref": "#/definitions/sales_force_id" }
-        },
-        "required": ["pos_payment_id", "sf_payment_id"]
-      }
-    },
-    "customer": {
-      "type": "object",
-      "properties": {
-        "pos_customer_id": { "type": "integer" },
-        "sf_customer_contact_id": { "$ref": "#/definitions/sales_force_id" }
-      },
-      "required": ["pos_customer_id", "sf_customer_contact_id"]
-    },
-    "participants": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "pos_participant_id": { "type": "integer" },
-          "sf_participant_contact_id": { "$ref": "#/definitions/sales_force_id" },
-          "sf_participant_id": { "$ref": "#/definitions/sales_force_id" }
-        },
-        "required": ["pos_participant_id", "sf_participant_contact_id", "sf_participant_id"]
-      }
     }
   },
-  "required": ["pos_order_id", "sf_order_id", "payments", "customer", "participants"],
+  "required": ["sf_order_id"],
   "definitions": {
     "sales_force_id": {
       "type": "string",


### PR DESCRIPTION
During a recent refactor of the incoming webhook processor, I discovered that I only really needed a single piece of information: the new `Order__c` object ID from the `sf_order_id` field.

With that single value, we can:

- Retrieve the `Order__c` object from Salesforce via our existing authentication.
- Use the value of the `Order_ID__c` field on the SF order object to get the ID of the Drupal Commerce order entity.
- Use the value of the `Purchaser__c` field to get the SF Contact for the Commerce order customer, which is a Drupal User entity.
- Look up the `EXECED_Application__c` object for the SF order.
- Look up the `EXECED_Participant__c` objects for the above application.
- Use the `POS_Participant_Id__c` field on the participant object to get the Drupal Participant entity, and, from that, the linked Drupal User account.
- Map all the Drupal entities to the corresponding Salesforce objects.

This has some advantages over the previous version of the schema:

- We no longer need to add authentication to the incoming webhook. The ID in the incoming `sf_order_id` field is verified by a lookup over an authenticated connection from the web server to Salesforce. If the `sf_order_id` is bogus, the incoming webhook processor will fail silently with a helpful log message.
- We no longer need to trust the incoming values of `pos_customer_id`, `pos_participant_id`, and `pos_payment_id`. We just get them right from the source over that same authenticated connection.

There are some possible disadvantages, too:

- The `Order_ID__c` and `POS_Participant_Id__c` fields MUST contain values for the Drupal entity lookups to work.
- Possibly other disadvantages? Can't think of any at the moment.